### PR TITLE
export clientHelloMsg for use in other programs

### DIFF
--- a/boring_test.go
+++ b/boring_test.go
@@ -29,7 +29,7 @@ func TestBoringServerProtocolVersion(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			serverConfig := testConfig.Clone()
 			serverConfig.MinVersion = VersionSSL30
-			clientHello := &clientHelloMsg{
+			clientHello := &ClientHelloMsg{
 				vers:               v,
 				random:             make([]byte, 32),
 				cipherSuites:       allCipherSuites(),
@@ -121,7 +121,7 @@ func TestBoringServerCipherSuites(t *testing.T) {
 		}
 		serverConfig.BuildNameToCertificate()
 		t.Run(fmt.Sprintf("suite=%#x", id), func(t *testing.T) {
-			clientHello := &clientHelloMsg{
+			clientHello := &ClientHelloMsg{
 				vers:               VersionTLS12,
 				random:             make([]byte, 32),
 				cipherSuites:       []uint16{id},
@@ -153,7 +153,7 @@ func TestBoringServerCurves(t *testing.T) {
 
 	for _, curveid := range defaultCurvePreferences {
 		t.Run(fmt.Sprintf("curve=%d", curveid), func(t *testing.T) {
-			clientHello := &clientHelloMsg{
+			clientHello := &ClientHelloMsg{
 				vers:               VersionTLS12,
 				random:             make([]byte, 32),
 				cipherSuites:       []uint16{TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
@@ -272,7 +272,7 @@ func TestBoringClientHello(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	hello, ok := msg.(*clientHelloMsg)
+	hello, ok := msg.(*ClientHelloMsg)
 	if !ok {
 		t.Fatalf("unexpected message type %T", msg)
 	}

--- a/conn.go
+++ b/conn.go
@@ -1038,7 +1038,7 @@ func (c *Conn) readHandshake() (any, error) {
 	case typeHelloRequest:
 		m = new(helloRequestMsg)
 	case typeClientHello:
-		m = new(clientHelloMsg)
+		m = new(ClientHelloMsg)
 	case typeServerHello:
 		m = new(serverHelloMsg)
 	case typeNewSessionTicket:

--- a/handshake_client.go
+++ b/handshake_client.go
@@ -27,7 +27,7 @@ type clientHandshakeState struct {
 	c            *Conn
 	ctx          context.Context
 	serverHello  *serverHelloMsg
-	hello        *clientHelloMsg
+	hello        *ClientHelloMsg
 	suite        *cipherSuite
 	finishedHash finishedHash
 	masterSecret []byte
@@ -36,7 +36,7 @@ type clientHandshakeState struct {
 
 var testingOnlyForceClientHelloSignatureAlgorithms []SignatureScheme
 
-func (c *Conn) makeFakeClientHello() (*clientHelloMsg, ecdheParameters, error) {
+func (c *Conn) makeFakeClientHello() (*ClientHelloMsg, ecdheParameters, error) {
 	config := c.config
 	if len(config.ServerName) == 0 && !config.InsecureSkipVerify {
 		return nil, nil, errors.New("tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config")
@@ -67,7 +67,7 @@ func (c *Conn) makeFakeClientHello() (*clientHelloMsg, ecdheParameters, error) {
 		clientHelloVersion = VersionTLS12
 	}
 
-	hello := &clientHelloMsg{
+	hello := &ClientHelloMsg{
 		vers:                         clientHelloVersion,
 		compressionMethods:           []uint8{compressionNone},
 		random:                       make([]byte, 32),
@@ -147,7 +147,7 @@ func (c *Conn) makeFakeClientHello() (*clientHelloMsg, ecdheParameters, error) {
 	return hello, params, nil
 }
 
-func (c *Conn) makeClientHello() (*clientHelloMsg, ecdheParameters, error) {
+func (c *Conn) makeClientHello() (*ClientHelloMsg, ecdheParameters, error) {
 	config := c.config
 	if len(config.ServerName) == 0 && !config.InsecureSkipVerify {
 		return nil, nil, errors.New("tls: either ServerName or InsecureSkipVerify must be specified in the tls.Config")
@@ -178,7 +178,7 @@ func (c *Conn) makeClientHello() (*clientHelloMsg, ecdheParameters, error) {
 		clientHelloVersion = VersionTLS12
 	}
 
-	hello := &clientHelloMsg{
+	hello := &ClientHelloMsg{
 		vers:                         clientHelloVersion,
 		compressionMethods:           []uint8{compressionNone},
 		random:                       make([]byte, 32),
@@ -454,7 +454,7 @@ func (c *Conn) fakeClientHandshake(ctx context.Context) (err error) {
 	return nil
 }
 
-func (c *Conn) loadSession(hello *clientHelloMsg) (cacheKey string,
+func (c *Conn) loadSession(hello *ClientHelloMsg) (cacheKey string,
 	session *ClientSessionState, earlySecret, binderKey []byte) {
 	if c.config.SessionTicketsDisabled || c.config.ClientSessionCache == nil {
 		return "", nil, nil, nil

--- a/handshake_client_test.go
+++ b/handshake_client_test.go
@@ -1453,7 +1453,7 @@ func TestHostnameInSNI(t *testing.T) {
 		c.Close()
 		s.Close()
 
-		var m clientHelloMsg
+		var m ClientHelloMsg
 		if !m.unmarshal(record) {
 			t.Errorf("unmarshaling ClientHello for %q failed", tt.in)
 			continue

--- a/handshake_client_tls13.go
+++ b/handshake_client_tls13.go
@@ -20,7 +20,7 @@ type clientHandshakeStateTLS13 struct {
 	c           *Conn
 	ctx         context.Context
 	serverHello *serverHelloMsg
-	hello       *clientHelloMsg
+	hello       *ClientHelloMsg
 	ecdheParams ecdheParameters
 
 	session     *ClientSessionState

--- a/handshake_messages.go
+++ b/handshake_messages.go
@@ -66,7 +66,7 @@ func readUint24LengthPrefixed(s *cryptobyte.String, out *[]byte) bool {
 	return s.ReadUint24LengthPrefixed((*cryptobyte.String)(out))
 }
 
-type clientHelloMsg struct {
+type ClientHelloMsg struct {
 	raw                              []byte
 	vers                             uint16
 	random                           []byte
@@ -94,7 +94,7 @@ type clientHelloMsg struct {
 	pskBinders                       [][]byte
 }
 
-func (m *clientHelloMsg) marshal() []byte {
+func (m *ClientHelloMsg) marshal() []byte {
 	if m.raw != nil {
 		return m.raw
 	}
@@ -303,7 +303,7 @@ func (m *clientHelloMsg) marshal() []byte {
 // marshalWithoutBinders returns the ClientHello through the
 // PreSharedKeyExtension.identities field, according to RFC 8446, Section
 // 4.2.11.2. Note that m.pskBinders must be set to slices of the correct length.
-func (m *clientHelloMsg) marshalWithoutBinders() []byte {
+func (m *ClientHelloMsg) marshalWithoutBinders() []byte {
 	bindersLen := 2 // uint16 length prefix
 	for _, binder := range m.pskBinders {
 		bindersLen += 1 // uint8 length prefix
@@ -317,7 +317,7 @@ func (m *clientHelloMsg) marshalWithoutBinders() []byte {
 // updateBinders updates the m.pskBinders field, if necessary updating the
 // cached marshaled representation. The supplied binders must have the same
 // length as the current m.pskBinders.
-func (m *clientHelloMsg) updateBinders(pskBinders [][]byte) {
+func (m *ClientHelloMsg) updateBinders(pskBinders [][]byte) {
 	if len(pskBinders) != len(m.pskBinders) {
 		panic("tls: internal error: pskBinders length mismatch")
 	}
@@ -343,8 +343,8 @@ func (m *clientHelloMsg) updateBinders(pskBinders [][]byte) {
 	}
 }
 
-func (m *clientHelloMsg) unmarshal(data []byte) bool {
-	*m = clientHelloMsg{raw: data}
+func (m *ClientHelloMsg) unmarshal(data []byte) bool {
+	*m = ClientHelloMsg{raw: data}
 	s := cryptobyte.String(data)
 
 	if !s.Skip(4) || // message type and uint24 length field

--- a/handshake_messages_test.go
+++ b/handshake_messages_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var tests = []any{
-	&clientHelloMsg{},
+	&ClientHelloMsg{},
 	&serverHelloMsg{},
 	&finishedMsg{},
 
@@ -113,8 +113,8 @@ func randomString(n int, rand *rand.Rand) string {
 	return string(b)
 }
 
-func (*clientHelloMsg) Generate(rand *rand.Rand, size int) reflect.Value {
-	m := &clientHelloMsg{}
+func (*ClientHelloMsg) Generate(rand *rand.Rand, size int) reflect.Value {
+	m := &ClientHelloMsg{}
 	m.vers = uint16(rand.Intn(65536))
 	m.random = randomBytes(32, rand)
 	m.sessionId = randomBytes(rand.Intn(32), rand)
@@ -470,7 +470,7 @@ func TestRejectDuplicateExtensions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to decode test ClientHello: %s", err)
 	}
-	var clientHelloCopy clientHelloMsg
+	var clientHelloCopy ClientHelloMsg
 	if clientHelloCopy.unmarshal(clientHelloBytes) {
 		t.Error("Unmarshaled ClientHello with duplicate extensions")
 	}

--- a/handshake_server.go
+++ b/handshake_server.go
@@ -25,7 +25,7 @@ import (
 type serverHandshakeState struct {
 	c            *Conn
 	ctx          context.Context
-	clientHello  *clientHelloMsg
+	clientHello  *ClientHelloMsg
 	hello        *serverHelloMsg
 	suite        *cipherSuite
 	ecdheOk      bool
@@ -128,12 +128,12 @@ func (hs *serverHandshakeState) handshake() error {
 }
 
 // readClientHello reads a ClientHello message and selects the protocol version.
-func (c *Conn) readClientHello(ctx context.Context) (*clientHelloMsg, error) {
+func (c *Conn) readClientHello(ctx context.Context) (*ClientHelloMsg, error) {
 	msg, err := c.readHandshake()
 	if err != nil {
 		return nil, err
 	}
-	clientHello, ok := msg.(*clientHelloMsg)
+	clientHello, ok := msg.(*ClientHelloMsg)
 	if !ok {
 		c.sendAlert(alertUnexpectedMessage)
 		return nil, unexpectedMessageError(clientHello, msg)
@@ -854,7 +854,7 @@ func (c *Conn) processCertsFromClient(certificate Certificate) error {
 	return nil
 }
 
-func clientHelloInfo(ctx context.Context, c *Conn, clientHello *clientHelloMsg) *ClientHelloInfo {
+func clientHelloInfo(ctx context.Context, c *Conn, clientHello *ClientHelloMsg) *ClientHelloInfo {
 	supportedVersions := clientHello.supportedVersions
 	if len(clientHello.supportedVersions) == 0 {
 		supportedVersions = supportedVersionsFromMax(clientHello.vers)

--- a/handshake_server_test.go
+++ b/handshake_server_test.go
@@ -34,7 +34,7 @@ func testClientHelloFailure(t *testing.T, serverConfig *Config, m handshakeMessa
 	c, s := localPipe(t)
 	go func() {
 		cli := Client(c, testConfig)
-		if ch, ok := m.(*clientHelloMsg); ok {
+		if ch, ok := m.(*ClientHelloMsg); ok {
 			cli.vers = ch.vers
 		}
 		cli.writeRecord(recordTypeHandshake, m.marshal())
@@ -74,12 +74,12 @@ func TestRejectBadProtocolVersion(t *testing.T) {
 	config := testConfig.Clone()
 	config.MinVersion = VersionSSL30
 	for _, v := range badProtocolVersions {
-		testClientHelloFailure(t, config, &clientHelloMsg{
+		testClientHelloFailure(t, config, &ClientHelloMsg{
 			vers:   v,
 			random: make([]byte, 32),
 		}, "unsupported versions")
 	}
-	testClientHelloFailure(t, config, &clientHelloMsg{
+	testClientHelloFailure(t, config, &ClientHelloMsg{
 		vers:              VersionTLS12,
 		supportedVersions: badProtocolVersions,
 		random:            make([]byte, 32),
@@ -87,7 +87,7 @@ func TestRejectBadProtocolVersion(t *testing.T) {
 }
 
 func TestNoSuiteOverlap(t *testing.T) {
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:               VersionTLS10,
 		random:             make([]byte, 32),
 		cipherSuites:       []uint16{0xff00},
@@ -97,7 +97,7 @@ func TestNoSuiteOverlap(t *testing.T) {
 }
 
 func TestNoCompressionOverlap(t *testing.T) {
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:               VersionTLS10,
 		random:             make([]byte, 32),
 		cipherSuites:       []uint16{TLS_RSA_WITH_RC4_128_SHA},
@@ -107,7 +107,7 @@ func TestNoCompressionOverlap(t *testing.T) {
 }
 
 func TestNoRC4ByDefault(t *testing.T) {
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:               VersionTLS10,
 		random:             make([]byte, 32),
 		cipherSuites:       []uint16{TLS_RSA_WITH_RC4_128_SHA},
@@ -121,7 +121,7 @@ func TestNoRC4ByDefault(t *testing.T) {
 }
 
 func TestRejectSNIWithTrailingDot(t *testing.T) {
-	testClientHelloFailure(t, testConfig, &clientHelloMsg{
+	testClientHelloFailure(t, testConfig, &ClientHelloMsg{
 		vers:       VersionTLS12,
 		random:     make([]byte, 32),
 		serverName: "foo.com.",
@@ -131,7 +131,7 @@ func TestRejectSNIWithTrailingDot(t *testing.T) {
 func TestDontSelectECDSAWithRSAKey(t *testing.T) {
 	// Test that, even when both sides support an ECDSA cipher suite, it
 	// won't be selected if the server's private key doesn't support it.
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:               VersionTLS10,
 		random:             make([]byte, 32),
 		cipherSuites:       []uint16{TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA},
@@ -157,7 +157,7 @@ func TestDontSelectECDSAWithRSAKey(t *testing.T) {
 func TestDontSelectRSAWithECDSAKey(t *testing.T) {
 	// Test that, even when both sides support an RSA cipher suite, it
 	// won't be selected if the server's private key doesn't support it.
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:               VersionTLS10,
 		random:             make([]byte, 32),
 		cipherSuites:       []uint16{TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA},
@@ -180,7 +180,7 @@ func TestDontSelectRSAWithECDSAKey(t *testing.T) {
 }
 
 func TestRenegotiationExtension(t *testing.T) {
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:                         VersionTLS12,
 		compressionMethods:           []uint8{compressionNone},
 		random:                       make([]byte, 32),
@@ -232,7 +232,7 @@ func TestRenegotiationExtension(t *testing.T) {
 func TestTLS12OnlyCipherSuites(t *testing.T) {
 	// Test that a Server doesn't select a TLS 1.2-only cipher suite when
 	// the client negotiates TLS 1.1.
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:   VersionTLS11,
 		random: make([]byte, 32),
 		cipherSuites: []uint16{
@@ -294,7 +294,7 @@ func TestTLSPointFormats(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			clientHello := &clientHelloMsg{
+			clientHello := &ClientHelloMsg{
 				vers:               VersionTLS12,
 				random:             make([]byte, 32),
 				cipherSuites:       tt.cipherSuites,
@@ -1037,7 +1037,7 @@ func TestHandshakeServerSNIGetCertificateError(t *testing.T) {
 		return nil, errors.New(errMsg)
 	}
 
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:               VersionTLS10,
 		random:             make([]byte, 32),
 		cipherSuites:       []uint16{TLS_RSA_WITH_RC4_128_SHA},
@@ -1058,7 +1058,7 @@ func TestHandshakeServerEmptyCertificates(t *testing.T) {
 	}
 	serverConfig.Certificates = nil
 
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:               VersionTLS10,
 		random:             make([]byte, 32),
 		cipherSuites:       []uint16{TLS_RSA_WITH_RC4_128_SHA},
@@ -1070,7 +1070,7 @@ func TestHandshakeServerEmptyCertificates(t *testing.T) {
 	// should always return a “no certificates” error.
 	serverConfig.GetCertificate = nil
 
-	clientHello = &clientHelloMsg{
+	clientHello = &ClientHelloMsg{
 		vers:               VersionTLS10,
 		random:             make([]byte, 32),
 		cipherSuites:       []uint16{TLS_RSA_WITH_RC4_128_SHA},
@@ -1417,7 +1417,7 @@ func TestClientAuth(t *testing.T) {
 func TestSNIGivenOnFailure(t *testing.T) {
 	const expectedServerName = "test.testing"
 
-	clientHello := &clientHelloMsg{
+	clientHello := &ClientHelloMsg{
 		vers:               VersionTLS10,
 		random:             make([]byte, 32),
 		cipherSuites:       []uint16{TLS_RSA_WITH_RC4_128_SHA},
@@ -1817,7 +1817,7 @@ func TestAESCipherReordering(t *testing.T) {
 					},
 					vers: VersionTLS12,
 				},
-				clientHello: &clientHelloMsg{
+				clientHello: &ClientHelloMsg{
 					cipherSuites: tc.clientCiphers,
 					vers:         VersionTLS12,
 				},
@@ -1914,7 +1914,7 @@ func TestAESCipherReorderingTLS13(t *testing.T) {
 					config: &Config{},
 					vers:   VersionTLS13,
 				},
-				clientHello: &clientHelloMsg{
+				clientHello: &ClientHelloMsg{
 					cipherSuites:       tc.clientCiphers,
 					supportedVersions:  []uint16{VersionTLS13},
 					compressionMethods: []uint8{compressionNone},

--- a/handshake_server_tls13.go
+++ b/handshake_server_tls13.go
@@ -26,7 +26,7 @@ const maxClientPSKIdentities = 5
 type serverHandshakeStateTLS13 struct {
 	c               *Conn
 	ctx             context.Context
-	clientHello     *clientHelloMsg
+	clientHello     *ClientHelloMsg
 	hello           *serverHelloMsg
 	sentDummyCCS    bool
 	usingPSK        bool
@@ -432,7 +432,7 @@ func (hs *serverHandshakeStateTLS13) doHelloRetryRequest(selectedGroup CurveID) 
 		return err
 	}
 
-	clientHello, ok := msg.(*clientHelloMsg)
+	clientHello, ok := msg.(*ClientHelloMsg)
 	if !ok {
 		c.sendAlert(alertUnexpectedMessage)
 		return unexpectedMessageError(clientHello, msg)
@@ -460,7 +460,7 @@ func (hs *serverHandshakeStateTLS13) doHelloRetryRequest(selectedGroup CurveID) 
 // illegalClientHelloChange reports whether the two ClientHello messages are
 // different, with the exception of the changes allowed before and after a
 // HelloRetryRequest. See RFC 8446, Section 4.1.2.
-func illegalClientHelloChange(ch, ch1 *clientHelloMsg) bool {
+func illegalClientHelloChange(ch, ch1 *ClientHelloMsg) bool {
 	if len(ch.supportedVersions) != len(ch1.supportedVersions) ||
 		len(ch.cipherSuites) != len(ch1.cipherSuites) ||
 		len(ch.supportedCurves) != len(ch1.supportedCurves) ||

--- a/key_agreement.go
+++ b/key_agreement.go
@@ -23,15 +23,15 @@ type keyAgreement interface {
 	// In the case that the key agreement protocol doesn't use a
 	// ServerKeyExchange message, generateServerKeyExchange can return nil,
 	// nil.
-	generateServerKeyExchange(*Config, *Certificate, *clientHelloMsg, *serverHelloMsg) (*serverKeyExchangeMsg, error)
+	generateServerKeyExchange(*Config, *Certificate, *ClientHelloMsg, *serverHelloMsg) (*serverKeyExchangeMsg, error)
 	processClientKeyExchange(*Config, *Certificate, *clientKeyExchangeMsg, uint16) ([]byte, error)
 
 	// On the client side, the next two methods are called in order.
 
 	// This method may not be called if the server doesn't send a
 	// ServerKeyExchange message.
-	processServerKeyExchange(*Config, *clientHelloMsg, *serverHelloMsg, *x509.Certificate, *serverKeyExchangeMsg) error
-	generateClientKeyExchange(*Config, *clientHelloMsg, *x509.Certificate) ([]byte, *clientKeyExchangeMsg, error)
+	processServerKeyExchange(*Config, *ClientHelloMsg, *serverHelloMsg, *x509.Certificate, *serverKeyExchangeMsg) error
+	generateClientKeyExchange(*Config, *ClientHelloMsg, *x509.Certificate) ([]byte, *clientKeyExchangeMsg, error)
 }
 
 var errClientKeyExchange = errors.New("tls: invalid ClientKeyExchange message")
@@ -41,7 +41,7 @@ var errServerKeyExchange = errors.New("tls: invalid ServerKeyExchange message")
 // encrypts the pre-master secret to the server's public key.
 type rsaKeyAgreement struct{}
 
-func (ka rsaKeyAgreement) generateServerKeyExchange(config *Config, cert *Certificate, clientHello *clientHelloMsg, hello *serverHelloMsg) (*serverKeyExchangeMsg, error) {
+func (ka rsaKeyAgreement) generateServerKeyExchange(config *Config, cert *Certificate, clientHello *ClientHelloMsg, hello *serverHelloMsg) (*serverKeyExchangeMsg, error) {
 	return nil, nil
 }
 
@@ -73,11 +73,11 @@ func (ka rsaKeyAgreement) processClientKeyExchange(config *Config, cert *Certifi
 	return preMasterSecret, nil
 }
 
-func (ka rsaKeyAgreement) processServerKeyExchange(config *Config, clientHello *clientHelloMsg, serverHello *serverHelloMsg, cert *x509.Certificate, skx *serverKeyExchangeMsg) error {
+func (ka rsaKeyAgreement) processServerKeyExchange(config *Config, clientHello *ClientHelloMsg, serverHello *serverHelloMsg, cert *x509.Certificate, skx *serverKeyExchangeMsg) error {
 	return errors.New("tls: unexpected ServerKeyExchange")
 }
 
-func (ka rsaKeyAgreement) generateClientKeyExchange(config *Config, clientHello *clientHelloMsg, cert *x509.Certificate) ([]byte, *clientKeyExchangeMsg, error) {
+func (ka rsaKeyAgreement) generateClientKeyExchange(config *Config, clientHello *ClientHelloMsg, cert *x509.Certificate) ([]byte, *clientKeyExchangeMsg, error) {
 	preMasterSecret := make([]byte, 48)
 	preMasterSecret[0] = byte(clientHello.vers >> 8)
 	preMasterSecret[1] = byte(clientHello.vers)
@@ -165,7 +165,7 @@ type ecdheKeyAgreement struct {
 	preMasterSecret []byte
 }
 
-func (ka *ecdheKeyAgreement) generateServerKeyExchange(config *Config, cert *Certificate, clientHello *clientHelloMsg, hello *serverHelloMsg) (*serverKeyExchangeMsg, error) {
+func (ka *ecdheKeyAgreement) generateServerKeyExchange(config *Config, cert *Certificate, clientHello *ClientHelloMsg, hello *serverHelloMsg) (*serverKeyExchangeMsg, error) {
 	var curveID CurveID
 	for _, c := range clientHello.supportedCurves {
 		if config.supportsCurve(c) {
@@ -267,7 +267,7 @@ func (ka *ecdheKeyAgreement) processClientKeyExchange(config *Config, cert *Cert
 	return preMasterSecret, nil
 }
 
-func (ka *ecdheKeyAgreement) processServerKeyExchange(config *Config, clientHello *clientHelloMsg, serverHello *serverHelloMsg, cert *x509.Certificate, skx *serverKeyExchangeMsg) error {
+func (ka *ecdheKeyAgreement) processServerKeyExchange(config *Config, clientHello *ClientHelloMsg, serverHello *serverHelloMsg, cert *x509.Certificate, skx *serverKeyExchangeMsg) error {
 	if len(skx.key) < 4 {
 		return errServerKeyExchange
 	}
@@ -348,7 +348,7 @@ func (ka *ecdheKeyAgreement) processServerKeyExchange(config *Config, clientHell
 	return nil
 }
 
-func (ka *ecdheKeyAgreement) generateClientKeyExchange(config *Config, clientHello *clientHelloMsg, cert *x509.Certificate) ([]byte, *clientKeyExchangeMsg, error) {
+func (ka *ecdheKeyAgreement) generateClientKeyExchange(config *Config, clientHello *ClientHelloMsg, cert *x509.Certificate) ([]byte, *clientKeyExchangeMsg, error) {
 	if ka.ckx == nil {
 		return nil, nil, errors.New("tls: missing ServerKeyExchange message")
 	}


### PR DESCRIPTION
Exporting clientHelloMsg allows another program to leverage existing Golang crypt/tls methods for create a ClientHello testing purposes.